### PR TITLE
Passing App Name To Auth

### DIFF
--- a/js/trello_docs.js
+++ b/js/trello_docs.js
@@ -9,6 +9,7 @@ $(document).ready(function(){
         scope: {
             write: false
         },
+        name: "Trello2HTML",
         success: initDoc
     };
 	if(typeof Trello==="undefined") {


### PR DESCRIPTION
## Purpose
We love using this integration to make printing boards easily. It worried a few people when they saw the auth page and it said, "Let An unknown application use your account?"

This PR just adds in the name of the app so that it is displayed during the auth process.

## Screenshot
<img width="578" alt="screen shot 2017-01-19 at 11 35 09 am" src="https://cloud.githubusercontent.com/assets/1723339/22115556/746c0086-de3b-11e6-8ef1-a67e4629da8c.png">
